### PR TITLE
add ranking module and find-by-date module

### DIFF
--- a/Backend/app/repository/repository.py
+++ b/Backend/app/repository/repository.py
@@ -1,4 +1,5 @@
 from sqlalchemy.orm import Session
+from sqlalchemy import cast, Date
 from ..domain.domains import  *
 
 
@@ -16,6 +17,9 @@ class BuggyCodeRepository:
         self.db.commit()
         self.db.refresh(buggy_code)
         return buggy_code
+
+    def findAllByDate(self, date: str):
+        return self.db.query(BuggyCode).filter(cast(BuggyCode.created_at, Date) == date).all()
 
 class FixedCodeRepository:
     def __init__(self, db:Session):

--- a/Backend/app/services/buggy_codes_service.py
+++ b/Backend/app/services/buggy_codes_service.py
@@ -1,6 +1,7 @@
 from sqlalchemy.orm import Session
 from ..domain.domains import BuggyCode
 from ..repository.repository import BuggyCodeRepository
+from datetime import datetime
 
 import sys
 class BuggyCodesService:
@@ -14,3 +15,7 @@ class BuggyCodesService:
 
     def find_one(self, id: int):
         return self.repo.findOne(id=id)
+
+    def find_all_by_date(self, date: str):
+        return self.repo.findAllByDate(date=date)
+

--- a/Backend/app/services/fixed_code_service.py
+++ b/Backend/app/services/fixed_code_service.py
@@ -1,12 +1,13 @@
 from ..domain.domains import FixedCode
 from sqlalchemy.orm import Session
-from ..repository.repository import FixedCodeRepository
+from ..repository.repository import FixedCodeRepository, BuggyCodeRepository
 
 class FixedCodeService:
 
     def __init__(self, db: Session):
         self.db = db
         self.repo = FixedCodeRepository(db)
+        self.buggyCodeRepo = BuggyCodeRepository(db)
     def create(self, new_fixed_code: FixedCode):
         return self.repo.create(new_fixed_code)
 
@@ -21,6 +22,24 @@ class FixedCodeService:
 
     def find_all_by_buggy_code(self, buggy_code_id: int):
         return self.repo.findAllByBuggyCode(buggy_code_id)
+
+    def find_all_by_date(self, date: str):
+        all_fixed_codes = self.repo.findAll()
+        find_buggy_codes = self.buggyCodeRepo.findAllByDate(date)
+        ret = []
+        for buggy_code in find_buggy_codes:
+            for fixed_code in all_fixed_codes:
+                if fixed_code.buggy_code_id == buggy_code.buggy_code_id:
+                    ret.append(fixed_code)
+        return ret
+
+    def rank_with_strategy(self, strategy_id: int, nRank: int):
+        allFixedCodeWithStrategy = self.repo.findAllByStrategy(strategy_id)
+        sortedFixedCodes = sorted(allFixedCodeWithStrategy, key=lambda x: x.reduced_rate, reverse=True)
+        if nRank < len(allFixedCodeWithStrategy):
+            return sortedFixedCodes[:nRank]
+        return sortedFixedCodes
+
 
     def delete_one(self, id: int):
         return self.repo.deleteOne(id)


### PR DESCRIPTION
### BuggyCode와 FixedCode에 세부 구현 로직을 추가했습니다.
추가한 기능은 아래와 같습니다

**1. 날짜 기반으로 BuggyCode와 FixedCode 조회**

- Request URL: 
> GET /api/buggyCodes/date/{조회할 날짜}
> GET /api/fixedCodes/date/{조회할 날짜}
- Response: 기존의 리스트 형식의 데이터 응답과 동일합니다.

**2. FixedCode 감소율 기준 랭킹 조회**

- Request URL : 
> GET /api/fixedCodes/ranking/{전략번호}/{랭킹수}
> 입력된 전략 번호에 해당하는 리팩터링 된 코드 중 상위 랭킹수 만큼의 코드를 리스트 형식으로 응답합니다.
- Response: 기존의 리스트 형식의 데이터 응답과 동일합니다.
- 존재하는 데이터보다, 더 많은 양의 랭킹 수를 입력하면, 전체 데이터가 정렬되어 리턴됩니다.

해당 기능을 프런트에서 다음과 같이 사용할 수 있습니다.

### case1. 5일간의 사용자 수 조회

GET /api/buggyCodes/date/{오늘날짜}
GET /api/buggyCodes/date/{오늘날짜-1}
GET /api/buggyCodes/date/{오늘날짜-2}
GET /api/buggyCodes/date/{오늘날짜-3}
GET /api/buggyCodes/date/{오늘날짜-4}

각 응답의 **nItems** 필드를 모두 더하면 5일간의 사용자 수 입니다.

### case2. 각 전략별 감소율 상위 5개 코드 조회

GET /api/fixedCodes/ranking/1/5 
이 요청의 응답은 1번 전략의 상위 5개 코드를 리턴합니다.

### case3. 전체 코드의 각 전략별 리팩터링 횟수

GET /api/fixedCodes

리팩터링 전략 고유번호(fix_strategy_id) 필드로 필터링을 한 후, 개수를 세면 쉽게 구할 수 있습니다. 날짜별로 구현하고 싶다면 _case1_ 과 유사하게 수행하면 됩니다.