### PR TITLE
cors setting for front-end

### DIFF
--- a/refactor-engine/build.gradle
+++ b/refactor-engine/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'skkuse.team7'
-version = '0.0.1-SNAPSHOT'
+version = '1.0.1'
 
 java {
 	sourceCompatibility = '17'
@@ -30,4 +30,7 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+bootJar {
+	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/refactor-engine/src/main/java/skkuse/team7/refactorengine/WebConfig.java
+++ b/refactor-engine/src/main/java/skkuse/team7/refactorengine/WebConfig.java
@@ -1,0 +1,22 @@
+package skkuse.team7.refactorengine;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig {
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("http://localhost:3000")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
+            }
+        };
+    }
+}
+


### PR DESCRIPTION
FE에서 refactoring-api 가 외부 API여서, cors 정책으로 인해 접근하지 못하는 문제가 있었습니다.

프론트엔드 포트인 3000번은 refactor-api에서 허용함으로써 문제를 해결했습니다. 배포 시, 배포 환경의 IP로 cors setting을 변경할 필요성이 있습니다.

