### PR TITLE
resolve some bugs in service layer & add "nRefactoring" attribute in response

### DIFF
--- a/refactor-engine/src/main/java/skkuse/team7/refactorengine/controller/RefactorController.java
+++ b/refactor-engine/src/main/java/skkuse/team7/refactorengine/controller/RefactorController.java
@@ -1,5 +1,7 @@
 package skkuse.team7.refactorengine.controller;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -42,9 +44,15 @@ public class RefactorController {
 
         Integer sig = 1;
         String currCode = request;
+
+        int nRefactoring1 = 0;
+        int nRefactoring2 = 0;
+        int nRefactoring3 = 0;
+
         RefactoringResult refactoringResult = refactorService.removeDuplicateGetSize(currCode, sig.toString());
         while (!refactoringResult.buggyPart().equals("")) {
             sig += 1;
+            nRefactoring1++;
             currCode = refactoringResult.fixedCode();
             refactoringResult = refactorService.removeDuplicateGetSize(currCode, sig.toString());
         }
@@ -52,6 +60,7 @@ public class RefactorController {
         currCode = refactoringResult.fixedCode();
         refactoringResult = refactorService.removeDuplicatedIf(currCode);
         while (!refactoringResult.buggyPart().equals("")) {
+            nRefactoring2++;
             currCode = refactoringResult.fixedCode();
             refactoringResult = refactorService.removeDuplicatedIf(currCode);
         }
@@ -59,10 +68,16 @@ public class RefactorController {
         currCode = refactoringResult.fixedCode();
         refactoringResult = refactorService.removeDuplicateObjectCreation(currCode);
         while (!refactoringResult.buggyPart().equals("")) {
+            nRefactoring3++;
             currCode = refactoringResult.fixedCode();
             refactoringResult = refactorService.removeDuplicateObjectCreation(currCode);
         }
 
-        return new ResponseEntity<EntireCodeResponse>(EntireCodeResponse.of(refactoringResult), HttpStatus.OK);
+        List<Integer> nRefactoring = new ArrayList<>();
+        nRefactoring.add(nRefactoring1);
+        nRefactoring.add(nRefactoring2);
+        nRefactoring.add(nRefactoring3);
+
+        return new ResponseEntity<EntireCodeResponse>(EntireCodeResponse.of(refactoringResult, nRefactoring), HttpStatus.OK);
     }
 }

--- a/refactor-engine/src/main/java/skkuse/team7/refactorengine/dto/EntireCodeResponse.java
+++ b/refactor-engine/src/main/java/skkuse/team7/refactorengine/dto/EntireCodeResponse.java
@@ -1,9 +1,10 @@
 package skkuse.team7.refactorengine.dto;
 
+import java.util.List;
 import skkuse.team7.refactorengine.domain.RefactoringResult;
 
-public record EntireCodeResponse(String fixedCodeText) {
-    public static EntireCodeResponse of(RefactoringResult result) {
-        return new EntireCodeResponse(result.fixedCode());
+public record EntireCodeResponse(String fixedCodeText, List<Integer> nRefactoring) {
+    public static EntireCodeResponse of(RefactoringResult result, List<Integer> nRefactoring) {
+        return new EntireCodeResponse(result.fixedCode(), nRefactoring);
     }
 }


### PR DESCRIPTION
### 리팩터링 전략1(for/while문 내부 반복문 제거) 관련해서 다음과 같은 버그가 존재해 개선하였습니다.

1. import 문이 존재할 경우, import 문까지 "public class Fixed {"으로 수정하는 문제
2. [var].size()가 여러개 존재할 경우, 리팩터링할 변수명을 잘 못 정하는 문제

### /refactoring/all 요청에 따른 응답에 nRefactoring 필드를 추가했습니다.

nRefactoring 필드는 정수(integer)를 요소로 갖는 리스트로, 각 리팩터링 전략이 몇번씩 사용됐는지를 의미합니다.

- case study: 1번 전략이 2번, 2번 전략이 1번, 3번 전략이 0번 사용됐다면 nRefactoring은 [2, 1, 0] 입니다.