### PR TITLE
add new column in fixedCode/buggyCode table & modify refactor-engine response & solve some error in refactoring 2

### DIFF
--- a/Backend/app/api/endpoints/buggy_codes_controller.py
+++ b/Backend/app/api/endpoints/buggy_codes_controller.py
@@ -59,3 +59,17 @@ def get_one_buggy_code(buggy_code_id: int, db: Session = Depends(database.get_db
             onSuccess=None,
             onError=exception_body)
 
+@router.get("/date/{date}")
+def get_buggy_codes(date: str, db: Session = Depends(database.get_db)):
+    buggyCodesService = BuggyCodesService(db)
+    findBuggyCodes = buggyCodesService.find_all_by_date(date)
+
+    return Response(
+        status=SUCCESS,
+        onSuccess=ListBody(
+            nItems=len(findBuggyCodes),
+            items=map(lambda buggyCoodes: BuggyCodeResponse.create(buggyCoodes), findBuggyCodes)
+        ),
+        onError=None
+    )
+

--- a/Backend/app/api/endpoints/fixed_codes_controller.py
+++ b/Backend/app/api/endpoints/fixed_codes_controller.py
@@ -25,7 +25,7 @@ def create_fixed_code(fixed_code: FixedCodeRequest, db: Session = Depends(databa
 def get_fixed_codes(db: Session = Depends(database.get_db)):
     fixedCodeService = FixedCodeService(db)
     fixed_codes = fixedCodeService.find_all()
-    return Response(status="succ`ess",
+    return Response(status="success",
                     onSuccess=ListBody(
                         nItems=len(fixed_codes),
                         items=map(lambda fixed_code: FixedCodeResponse.create(fixed_code), fixed_codes)),
@@ -80,3 +80,23 @@ def delete_fixed_code(fixed_code_id: int, db: Session = Depends(database.get_db)
         return Response(status="fail",
                         onSuccess=None,
                         onError=exception_body)
+
+@router.get("/ranking/{strategy_id}/{nRank}")
+def get_one_fixed_code_by_strategy(strategy_id: int, nRank: int, db: Session = Depends(database.get_db)):
+    fixedCodeService = FixedCodeService(db)
+    findFixedCodes = fixedCodeService.rank_with_strategy(strategy_id, nRank)
+    return Response(status="success",
+                    onSuccess=ListBody(
+                        nItems=len(findFixedCodes),
+                        items=map(lambda fixed_code: FixedCodeResponse.create(fixed_code), findFixedCodes)),
+                    onError=None)
+
+@router.get("/date/{date}")
+def get_all_fixed_codes_by_date(date: str, db: Session = Depends(database.get_db)):
+    fixedCodeService = FixedCodeService(db)
+    findFixedCodes = fixedCodeService.find_all_by_date(date)
+    return Response(status="success",
+                    onSuccess=ListBody(
+                        nItems=len(findFixedCodes),
+                        items=map(lambda fixed_code: FixedCodeResponse.create(fixed_code), findFixedCodes)),
+                    onError=None)

--- a/Backend/app/domain/domains.py
+++ b/Backend/app/domain/domains.py
@@ -12,6 +12,7 @@ class BuggyCode(Base):
     __tablename__ = 'buggy_code'
     buggy_code_id = Column(Integer, primary_key=True, autoincrement=True)
     code_text = Column(Text, nullable=False)
+    fixed_code_text = Column(Text, nullable=False)
     created_at = Column(DateTime, nullable=False)
     emission_amount = Column(Float, nullable=False)
     core_type = Column(String(10), nullable=False)
@@ -24,6 +25,7 @@ class BuggyCode(Base):
     def create(buggy_code_req: BuggyCodeRequest):
         return BuggyCode(
             code_text=buggy_code_req.code_text,
+            fixed_code_text=buggy_code_req.fixed_code_text,
             created_at=datetime.datetime.now(),
             emission_amount=buggy_code_req.emission_amount,
             core_type=buggy_code_req.core_type,
@@ -35,6 +37,7 @@ class BuggyCode(Base):
 class FixedCode(Base):
     __tablename__ = 'fixed_code'
     fixed_code_id = Column(Integer, primary_key=True, autoincrement=True)
+    fixed_code_text = Column(Text, nullable=False)
     buggy_part = Column(Text, nullable=False)
     fixed_part = Column(Text, nullable=False)
     reduced_amount = Column(Float)
@@ -48,6 +51,7 @@ class FixedCode(Base):
     @staticmethod
     def create(fixed_code_req: FixedCodeRequest):
         return FixedCode(
+            fixed_code_text=fixed_code_req.fixed_code_text,
             buggy_part=fixed_code_req.buggy_part,
             fixed_part=fixed_code_req.fixed_part,
             reduced_amount=fixed_code_req.reduced_amount,

--- a/Backend/app/models/requests.py
+++ b/Backend/app/models/requests.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel
 from typing import Optional
 
 class FixedCodeRequest(BaseModel):
+    fixed_code_text: str
     buggy_part: str
     fixed_part: str
     reduced_amount: float
@@ -11,6 +12,7 @@ class FixedCodeRequest(BaseModel):
 
 class BuggyCodeRequest(BaseModel):
     code_text: str
+    fixed_code_text: str
     emission_amount: float
     core_type: str
     core_model: str

--- a/Backend/app/models/response.py
+++ b/Backend/app/models/response.py
@@ -21,6 +21,7 @@ class ListBody(BaseModel):
 class BuggyCodeResponse(BaseModel):
     buggy_code_id: int
     code_text: str
+    fixed_code_text: str
     create_at: datetime
     emission_amount: float
     core_type: str
@@ -35,6 +36,7 @@ class BuggyCodeResponse(BaseModel):
         return BuggyCodeResponse(
             buggy_code_id=buggyCode.buggy_code_id,
             code_text=buggyCode.code_text,
+            fixed_code_text=buggyCode.fixed_code_text,
             create_at=buggyCode.created_at.strftime("%Y-%m-%d"),
             emission_amount=buggyCode.emission_amount,
             core_type=buggyCode.core_type,
@@ -45,6 +47,7 @@ class BuggyCodeResponse(BaseModel):
 
 class FixedCodeResponse(BaseModel):
     fixed_code_id: int
+    fixed_code_text: str
     buggy_part: str
     fixed_part: str
     reduced_amount: float
@@ -59,6 +62,7 @@ class FixedCodeResponse(BaseModel):
     def create(fixedCode: FixedCode):
         return FixedCodeResponse(
             fixed_code_id=fixedCode.fixed_code_id,
+            fixed_code_text=fixedCode.fixed_code_text,
             buggy_part=fixedCode.buggy_part,
             fixed_part=fixedCode.fixed_part,
             reduced_amount=fixedCode.reduced_amount,

--- a/Backend/tests/controller/test_buggy_codes_controller.py
+++ b/Backend/tests/controller/test_buggy_codes_controller.py
@@ -24,6 +24,7 @@ def mock_buggy_code_json_1():
     return {
     "buggy_code_id": 1,
     "code_text": "code_text",
+    "fixed_code_text": "fixed_code_text",
     "create_at": "2020-01-01",
     "emission_amount": 1.0,
     "core_type": "core_type",
@@ -37,6 +38,7 @@ def mock_buggy_code_1():
     return BuggyCode(
         buggy_code_id=1,
         code_text="code_text",
+        fixed_code_text="fixed_code_text",
         created_at=datetime(2020, 1, 1),
         emission_amount=1.0,
         core_type="core_type", core_model="core_model", core_num=1, memory=1)
@@ -46,6 +48,7 @@ def mock_buggy_code_json_2():
     return {
     "buggy_code_id": 2,
     "code_text": "code_text",
+    "fixed_code_text": "fixed_code_text",
     "create_at": "2020-01-01",
     "emission_amount": 1.0,
     "core_type": "core_type",
@@ -58,6 +61,7 @@ def  mock_buggy_code_2():
     return BuggyCode(
         buggy_code_id=2,
         code_text="code_text",
+        fixed_code_text="fixed_code_text",
         created_at=datetime(2020, 1, 1),
         emission_amount=1.0,
         core_type="core_type", core_model="core_model", core_num=1, memory=1)
@@ -67,6 +71,7 @@ def mock_buggy_code_json_3():
     return {
         "buggy_code_id": 3,
         "code_text": "code_text",
+        "fixed_code_text": "fixed_code_text",
         "create_at": "2020-01-01",
         "emission_amount": 1.0,
         "core_type": "core_type",
@@ -80,6 +85,7 @@ def mock_buggy_code_3():
     return BuggyCode(
         buggy_code_id=3,
         code_text="code_text",
+        fixed_code_text="fixed_code_text",
         created_at=datetime(2020, 1, 1),
         emission_amount=1.0,
         core_type="core_type", core_model="core_model", core_num=1, memory=1)

--- a/Backend/tests/controller/test_fixed_code_controller.py
+++ b/Backend/tests/controller/test_fixed_code_controller.py
@@ -13,6 +13,7 @@ client = TestClient(app)
 def mock_fixed_code_json_1():
     return {
         "fixed_code_id": 1,
+        "fixed_code_text": "fixed_code_text",
         "buggy_part": "buggy part",
         "fixed_part": "fixed part",
         "reduced_amount": 0.0,
@@ -25,6 +26,7 @@ def mock_fixed_code_json_1():
 def mock_fixed_code_1():
     return FixedCode(
         fixed_code_id=1,
+        fixed_code_text="fixed_code_text",
         buggy_part="buggy part",
         fixed_part="fixed part",
         reduced_amount=0.0,
@@ -37,6 +39,7 @@ def mock_fixed_code_1():
 def mock_fixed_code_json_2():
     return {
         "fixed_code_id": 2,
+        "fixed_code_text": "fixed_code_text",
         "buggy_part": "buggy part",
         "fixed_part": "fixed part",
         "reduced_amount": 0.0,
@@ -49,6 +52,7 @@ def mock_fixed_code_json_2():
 def mock_fixed_code_2():
     return FixedCode(
         fixed_code_id=2,
+        fixed_code_text="fixed_code_text",
         buggy_part="buggy part",
         fixed_part="fixed part",
         reduced_amount=0.0,
@@ -61,6 +65,7 @@ def mock_fixed_code_2():
 def mock_fixed_code_json_3():
     return {
         "fixed_code_id": 3,
+        "fixed_code_text": "fixed_code_text",
         "buggy_part": "buggy part",
         "fixed_part": "fixed part",
         "reduced_amount": 0.0,
@@ -73,6 +78,7 @@ def mock_fixed_code_json_3():
 def mock_fixed_code_3():
     return FixedCode(
         fixed_code_id=3,
+        fixed_code_text="fixed_code_text",
         buggy_part="buggy part",
         fixed_part="fixed part",
         reduced_amount=0.0,

--- a/refactor-engine/src/main/java/skkuse/team7/refactorengine/dto/CodePartResponse.java
+++ b/refactor-engine/src/main/java/skkuse/team7/refactorengine/dto/CodePartResponse.java
@@ -1,10 +1,12 @@
 package skkuse.team7.refactorengine.dto;
 
+import java.util.ArrayList;
+import java.util.List;
 import skkuse.team7.refactorengine.domain.RefactoringResult;
 
-public record CodePartResponse(Long refactorId, String buggyPart, String fixedPart) {
+public record CodePartResponse(Long refactorId, String entireCode, int nRefactorting, List<String> buggyParts, List<String> fixedParts) {
 
-    public static CodePartResponse of(Long refactorId, RefactoringResult result) {
-        return new CodePartResponse(refactorId, result.buggyPart(), result.fixedPart());
+    public static CodePartResponse of(Long refactorId, RefactoringResult result, int nRefactorting, List<String> buggyParts, List<String> fixedParts) {
+        return new CodePartResponse(refactorId, result.fixedCode(), nRefactorting, buggyParts, fixedParts);
     }
 }


### PR DESCRIPTION
### buggy_code 테이블과 fixed_code 테이블에 각각 전체 리팩터링 코드를 저장할 fixed_code_text 라는 칼럼을 추가했습니다.

- 이에 따라, BuggyCode 엔티티와 FixedCode 엔티티에 대한 응답바디와 요청바디 형식에도 각각 "fixed_code_text" 가 추가 되었습니다.
- DB의 경우, DDL_AUTO: CREATE으로 설정되어 있으므로, 디비에 모든 테이블을 지우고 서버를 시작하면 수정된 테이블이 자동으로 삽입됩니다. _(DB를 수정하지 않고 서버를 실행할 경우, 서버 내부 에러 발생합니다!)_

### refactor-engine GET /refactoring/{전략번호} 요청에 대한 처리 로직 및 응답 형식이 변경되었습니다

- 기존의 로직이 경우, 같은 전략으로 수정할 수 있는 코드 파트가 여러개 있어도, 단 하나만 수정하였지만 수정된 로직에서는 모든 변경 가능한 사안을 변경합니다. 
- 이에 따라, 응답형식에도 수정된 전체 코드를 의미하는 "entire_code"가 추가 되었습니다. 
- 여러번 수정할 경우, buggyPart와 fixed_Part가 여러개 존재하므로  응답 바디에서 fixedPart와 buggyPart는 각각 fixed_parts와 buggy_parts로 변경되었으면 데이터 타입은 리스트입니다.

### Refactoring 2번 전략에 존재했던 중대한 버그를 수정했습니다.

- if 문이 복잡하게 겹쳐져 있을 경우, 버그가 빈번하게 발생함을 탐지하고 로직의 핵심적인 부분을 수정하였습니다.

_p.s. 1,3번 전략에 비해 2번 전략이 로직이 많이 복잡합니다. 추후에 많은 테스트를 통해 지속적인 개선이 필요하다고 생각합니다 😭_ 